### PR TITLE
Add support for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ addons:
   postgresql: "9.3"
 before_install:
   - sudo apt-get update
+  # remove zope.interface installed from aptitude
+  - sudo apt-get purge python-zope.interface
+  # Install the 'plpython' extension language
 
   # Installation for cnx-archive:
   # * Install the 'plpython' extension language
@@ -35,8 +38,6 @@ before_install:
 
   # Install the coverage utility and coveralls reporting utility
   - sudo apt-get install python-pip
-  # Install test requirements
-  - sudo /usr/bin/pip install mock webtest
   # Scripts get installed to /usr/local/bin
   - sudo /usr/bin/pip install coverage
   - sudo /usr/bin/pip install coveralls
@@ -50,8 +51,8 @@ before_script:
 env:
   - TESTING_CONFIG="testing.ini"
 script:
-  # This is the same as `python -m unittest discover` with a coverage wrapper.
-  - /usr/local/bin/coverage run --source=cnxpublishing -m unittest discover
+  # This is the same as `python setup.py test` with a coverage wrapper.
+  - sudo /usr/local/bin/coverage run --source=cnxpublishing setup.py test
 after_success:
   # Report test coverage to coveralls.io
   - /usr/local/bin/coveralls

--- a/cnxpublishing/main.py
+++ b/cnxpublishing/main.py
@@ -28,5 +28,5 @@ def main(global_config, **settings):
     config = Configurator(settings=settings)
     declare_routes(config)
 
-    config.scan()
+    config.scan(ignore='cnxpublishing.tests')
     return config.make_wsgi_app()

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras_require = {
 description = """\
 Application for accepting publication requests to the Connexions Archive."""
 
-if IS_PY3:
+if not IS_PY3:
     tests_require.append('mock')
 
 setup(
@@ -34,6 +34,7 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require=extras_require,
+    test_suite='cnxpublishing.tests',
     packages=find_packages(),
     include_package_data=True,
     entry_points="""\


### PR DESCRIPTION
`python-zope.interface` was installed in aptitude, and it was an old version that doesn't have `registry`.  Removing it fixes the tests.

Skip cnxpublishing.tests in configurator scan

To fix the following error:

```
      File "/home/karen/cnx-publishing/cnxpublishing/main.py", line 31, in main
        config.scan()
      File "/usr/local/lib/python2.7/dist-packages/pyramid-1.4.4-py2.7.egg/pyramid/config/__init__.py", line 947, in scan
        ignore=ignore)
      File "/usr/local/lib/python2.7/dist-packages/venusian-1.0a8-py2.7.egg/venusian/__init__.py", line 199, in scan
        __import__(modname)
      File "/home/karen/cnx-publishing/cnxpublishing/tests/test_publish.py", line 16, in <module>
        import mock
    ImportError: No module named mock
```
