### PR TITLE
Set resource filenames when publishing pending resources

### DIFF
--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -529,7 +529,7 @@ FROM pending_resources
 WHERE hash = %s""", (hash,))
                 data, media_type = cursor.fetchone()
                 document.resources.append(cnxepub.Resource(
-                    hash, io.BytesIO(data), media_type))
+                    hash, io.BytesIO(data), media_type, filename=hash))
 
         ident_hash = publish_model(cursor, document, publisher, message)
 


### PR DESCRIPTION
There is a unique constraint on the module_files table for
(module_ident, filename).

Publish pending resources was failing because filename was not set.

Fix #15
