### PR TITLE
Make sure resource links in published content use md5 hash

### DIFF
--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -720,8 +720,13 @@ SELECT data, media_type
 FROM pending_resources
 WHERE hash = %s""", (hash,))
                 data, media_type = cursor.fetchone()
+                # FIXME md5 code to be removed when database is migrated to
+                # use sha1 hash
+                import hashlib
+                md5 = hashlib.new('md5', data[:]).hexdigest()
                 document.resources.append(cnxepub.Resource(
-                    hash, io.BytesIO(data[:]), media_type, filename=hash))
+                    md5, io.BytesIO(data[:]), media_type, filename=hash))
+                ref.bind(document.resources[-1], '/resources/{}')
 
         ident_hash = publish_model(cursor, document, publisher, message)
         all_models.append(document)


### PR DESCRIPTION
This can be revoked when "files" table is migrated to use sha1 hash
