### PR TITLE
Add resource file upload size limit when publishing

### DIFF
--- a/cnxpublishing/exceptions.py
+++ b/cnxpublishing/exceptions.py
@@ -220,3 +220,24 @@ class InvalidDocumentPointer(PublicationException):
         data['exists'] = self._exists
         data['is_document'] = self._is_document
         return data
+
+
+class ResourceFileExceededLimitError(PublicationException):
+    """Raised when a user tries to publish a document with resource
+    files bigger than the size limit
+    """
+    code = 22
+    _message_template = ('Resource files cannot be bigger than {size_limit}MB'
+                         ' ({filename})')
+
+    def __init__(self, size_limit, filename):
+        super(ResourceFileExceededLimitError, self).__init__()
+        self._size_limit = size_limit
+        self._filename = filename
+
+    @property
+    def __dict__(self):
+        data = super(ResourceFileExceededLimitError, self).__dict__
+        data['size_limit'] = self._size_limit
+        data['filename'] = self._filename
+        return data

--- a/cnxpublishing/tests/test_views.py
+++ b/cnxpublishing/tests/test_views.py
@@ -613,13 +613,13 @@ class PublishingAPIFunctionalTestCase(BaseFunctionalViewTestCase):
         self.assertEqual(resp.json['state'], expected_state)
 
     def app_post_publication(self, epub_filepath, is_pre_publication=False,
-                             headers=[]):
+                             headers=[], status=None):
         with open(epub_filepath, 'rb') as epub:
             params = OrderedDict(
                 [('pre-publication', str(is_pre_publication),),
                  ('epub', Upload('book.epub', content=epub.read()),)])
         resp = self.app.post('/publications', params=params,
-                             headers=headers)
+                             headers=headers, status=status)
         return resp
 
     def app_get_license_acceptance(self, publication_id, uid, headers=[]):
@@ -1378,5 +1378,28 @@ WHERE portal_type = 'Collection'""")
                          [(10, u'InvalidLicense'), (11, u'InvalidRole')])
 
         # *. --
+        self.app_check_state(publication_id, 'Failed/Error',
+                             headers=api_key_headers)
+
+    def test_new_to_publication_size_limit_exceeded(self):
+        publisher = u'ream'
+        use_case = deepcopy(use_cases.BOOK)
+        use_case.append(use_cases.PAGE_FIVE)
+        epub_filepath = self.make_epub(use_case, publisher,
+                                       u'públishing this book')
+        api_key = self.api_keys_by_uid['some-trust']
+        api_key_headers = [('x-api-key', api_key,)]
+
+        resp = self.app_post_publication(epub_filepath, headers=api_key_headers)
+        self.assertEqual(resp.json['state'], 'Failed/Error')
+        publication_id = resp.json['publication']
+        self.maxDiff = None
+        error_messages = resp.json['messages']
+        self.assertEqual(len(error_messages), 1)
+        self.assertEqual(error_messages[0]['code'], 22)
+        self.assertEqual(
+                error_messages[0]['message'],
+                'Resource files cannot be bigger than 1MB (big-file.txt)')
+
         self.app_check_state(publication_id, 'Failed/Error',
                              headers=api_key_headers)

--- a/cnxpublishing/tests/use_cases.py
+++ b/cnxpublishing/tests/use_cases.py
@@ -291,6 +291,46 @@ PAGE_FOUR = cnxepub.Document(
         }
     )
 
+PAGE_FIVE = cnxepub.Document(
+    id=u'b3627ba5@draft',
+    data=u'<p class="para">Download big file <a href="../resources/big-file.txt">here</a></p>',
+    resources=[
+        cnxepub.Resource('big-file.txt',
+                         # a 2 MB file
+                         io.BytesIO('a ' * 1024 * 1024),
+                         'text/plain',
+                         filename='big-file.txt'),
+        ],
+    metadata={
+        u'title': u'Document Five',
+        u'created': u'2013/03/19 15:01:16 -0500',
+        u'revised': u'2013/03/19 15:01:16 -0500',
+        u'keywords': [u'South Africa'],
+        u'subjects': [u'Science and Technology'],
+        u'summary': u'<span>descriptive text</span>',
+        u'language': u'en',
+        u'license_text': u'CC-By 4.0',
+        u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
+        u'authors': [{u'id': u'charrose',
+                      u'name': u'Charmaine St. Rose',
+                      u'type': u'cnx-id'},
+                      ],
+        u'copyright_holders': [
+            {u'id': u'ream',
+             u'name': u'Ream',
+             u'type': u'cnx-id'}],
+        u'editors': [],
+        u'illustrators': [],
+        u'publishers': [{u'id': u'ream',
+                         u'name': u'Ream',
+                         u'type': u'cnx-id'},
+                        {u'id': u'charrose',
+                         u'name': u'Charmaine St. Rose',
+                         u'type': u'cnx-id'}],
+        u'translators': []
+        }
+    )
+
 COMPLEX_BOOK_ONE = cnxepub.Binder(
     id='94f4d0f5@draft',
     metadata={

--- a/development.ini
+++ b/development.ini
@@ -14,6 +14,8 @@ pyramid.default_locale_name = en
 pyramid.includes =
 
 db-connection-string = dbname=cnxarchive user=cnxarchive password=cnxarchive
+# size limit of file uploads in MB
+file-upload-limit = 50
 
 session_key = 'somkindaseekret'
 # Application API keys with authentication information.

--- a/testing.ini
+++ b/testing.ini
@@ -4,6 +4,8 @@ db-connection-string = dbname=cnxarchive-testing user=cnxarchive password=cnxarc
 api-key-authnz =
   4e8,no-trust,
   b07,some-trust,group:trusted-publishers
+# size limit of file uploads in MB
+file-upload-limit = 1
 openstax_accounts.stub = true
 openstax_accounts.stub.users =
   charrose,charrose


### PR DESCRIPTION
MANUAL-UPGRADE: Size limit setting "file-upload-limit" should be added
to configuration file (e.g. development.ini)
