### PR TITLE
Add Sentry integration for exception tracking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7
 
-RUN set -x && python -m pip install pyramid_sawing
+RUN set -x && python -m pip install pyramid_sawing sentry-sdk
 
 COPY . /src
 WORKDIR /src

--- a/cnxpublishing/config.py
+++ b/cnxpublishing/config.py
@@ -6,6 +6,8 @@
 # See LICENCE.txt for details.
 # ###
 import os
+import warnings
+
 from cnxarchive.config import CONNECTION_STRING
 from pyramid import security
 from pyramid.config import Configurator
@@ -63,6 +65,41 @@ def expandvars_dict(settings):
     )
 
 
+def initialize_sentry_integration():  # pragma: no cover
+    """\
+    Used to optionally initialize the Sentry service with this app.
+    See https://docs.sentry.io/platforms/python/pyramid/
+
+    """
+    # This function is not under coverage because it is boilerplate
+    # from the Sentry documentation.
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.pyramid import PyramidIntegration
+        from sentry_sdk.integrations.celery import CeleryIntegration
+    except ImportError:
+        warnings.warn(
+            "Sentry is not configured because the Sentry SDK "
+            "(sentry_sdk package) is not installed",
+            UserWarning,
+        )
+        return  # bail out early
+
+    try:
+        dsn = os.environ['SENTRY_DSN']
+    except KeyError:
+        warnings.warn(
+            "Sentry is not configured because SENTRY_DSN "
+            "was not supplied.",
+            UserWarning,
+        )
+    else:
+        sentry_sdk.init(
+            dsn=dsn,
+            integrations=[PyramidIntegration(), CeleryIntegration()],
+        )
+
+
 def configure(settings):
     # load environment variables
     settings = expandvars_dict(settings)
@@ -74,6 +111,8 @@ def configure(settings):
         'missing {} setting'.format('channel_processing.channels'))
     assert CONNECTION_STRING in settings, (
         'missing {} setting'.format(CONNECTION_STRING))
+
+    initialize_sentry_integration()
 
     # Create the configuration object
     config = Configurator(settings=settings, root_factory=RootFactory)


### PR DESCRIPTION
This uses the Sentry SDK to integrate with our Sentry install.
Note this has been made optional by wrapping the code in try..except
blocks.