### PR TITLE
Avoid double encoding when publishing content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ before_install:
   # remove zope.interface installed from aptitude
   - sudo apt-get purge python-zope.interface
 
+  # Uninstall pytest as it is old and it will be installed further down
+  - pip uninstall -y pytest
+
   # Stop local postgres
   - sudo service postgresql stop
 
@@ -50,7 +53,6 @@ before_script:
   - docker-compose -f .travis-compose.yml exec db /bin/bash -c "echo 'ALTER USER cnxarchive WITH SUPERUSER' | psql -U postgres postgres"
   # Stop init_venv from doing anything
   - docker-compose -f .travis-compose.yml exec db /bin/bash -c "echo 'CREATE SCHEMA venv' | psql -U cnxarchive cnxarchive-testing"
-  - pip install -U pytest pytest-runner pytest-cov
 script:
   # This is the same as `coverage run setup.py test`.
   - AS_VENV_IMPORTABLE=false pytest cnxpublishing

--- a/cnxpublishing/publish.py
+++ b/cnxpublishing/publish.py
@@ -337,7 +337,7 @@ def publish_model(cursor, model, publisher, message):
         _insert_resource_file(cursor, module_ident, resource)
 
     if isinstance(model, Document):
-        html = str(cnxepub.DocumentContentFormatter(model)).encode('utf-8')
+        html = bytes(cnxepub.DocumentContentFormatter(model))
         sha1 = hashlib.new('sha1', html).hexdigest()
         cursor.execute("SELECT fileid FROM files WHERE sha1 = %s", (sha1,))
         try:
@@ -390,9 +390,8 @@ def publish_composite_model(cursor, model, parent_model, publisher, message):
         _insert_resource_file(cursor, module_ident, resource)
 
     if isinstance(model, CompositeDocument):
-        html = str(cnxepub.DocumentContentFormatter(model))
-        fileid, _ = _insert_file(cursor, io.BytesIO(html.encode('utf-8')),
-                                 'text/html')
+        html = bytes(cnxepub.DocumentContentFormatter(model))
+        fileid, _ = _insert_file(cursor, io.BytesIO(html), 'text/html')
         file_arg = {
             'module_ident': module_ident,
             'parent_ident_hash': parent_model.ident_hash,
@@ -417,7 +416,7 @@ def publish_collated_document(cursor, model, parent_model):
     the archive.
 
     """
-    html = str(cnxepub.DocumentContentFormatter(model)).encode('utf-8')
+    html = bytes(cnxepub.DocumentContentFormatter(model))
     sha1 = hashlib.new('sha1', html).hexdigest()
     cursor.execute("SELECT fileid FROM files WHERE sha1 = %s", (sha1,))
     try:

--- a/cnxpublishing/tests/use_cases.py
+++ b/cnxpublishing/tests/use_cases.py
@@ -349,7 +349,7 @@ PAGE_THREE = cnxepub.Document(
 
 PAGE_FOUR = cnxepub.Document(
     id=u'deadbeef@draft',
-    data=u'<p class="para">If you finish the book, there will be cake.</p>',
+    data=u'<p class="para">If you finish the böök, there will be cake.</p>',
     metadata={
         u'title': u'Document Four of Infinity',
         u'created': u'2013/03/19 15:01:16 -0500',

--- a/cnxpublishing/tests/views/test_publishing.py
+++ b/cnxpublishing/tests/views/test_publishing.py
@@ -1391,12 +1391,12 @@ class BakeContentTestCase(BaseFunctionalViewTestCase):
         # FIXME use collate with real ruleset when it is available
 
         # Add some fake collation objects to the book.
-        content = '<p>composite</p>'
+        content = '<p>compösite</p>'
         publisher, message, composite_doc = self.make_one(binder, content)
         composite_section = cnxepub.TranslucentBinder(
             nodes=[composite_doc],
             metadata={'title': "Other things"})
-        collated_doc_content = '<p>collated</p>'
+        collated_doc_content = '<p>cöllated</p>'
 
         def _collate(binder_model, ruleset=None, includes=None):
             binder_model[0][0].content = collated_doc_content

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ install_requires = (
 )
 tests_require = [
     'cnx-db',
-    'pytest',
+    'pytest<4.1.0',
     'pytest-cov',
     'pytest-mock',
     'pytest-runner',


### PR DESCRIPTION
In python 2, when calling `str(DocumentContentFormatter())`, the result
is already encoded, so calling `.encode('utf-8')` breaks when there are
unicode character:

```
Traceback (most recent call last):
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/celery/app/trace.py", line 382, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxpublishing/tasks.py", line 31, in __call__
    return super(PyramidAwareTask, self).__call__(*args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/celery/app/trace.py", line 641, in __protected_call__
    return self.run(*args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxpublishing/db.py", line 74, in wrapped
    return func(*args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxpublishing/subscribers.py", line 167, in baking_processor
    bake(binder, recipe_id, publisher, message, cursor=cursor)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxpublishing/db.py", line 70, in wrapped
    return func(*args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxpublishing/bake.py", line 85, in bake
    publish_composite_model(cursor, doc, binder, publisher, message)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxpublishing/publish.py", line 394, in publish_composite_model
    fileid, _ = _insert_file(cursor, io.BytesIO(html.encode('utf-8')),
UnicodeDecodeError: 'ascii' codec can't decode byte 0xce in position 2206: ordinal not in range(128)
```

The reason this used to work is `DocumentContentFormatter` used to return an
ascii string (with `&#920;` instead of Θ) which does not output any errors in
python 2 if it is encoded twice.

By explicitly using `bytes(DocumentContentFormatter())`, we can keep the
type the same in python 2 and 3, so we know not to call `.encode()` on
the result.