### PR TITLE
Document content fix in tests

### DIFF
--- a/cnxpublishing/tests/test_bake.py
+++ b/cnxpublishing/tests/test_bake.py
@@ -61,13 +61,13 @@ WHERE
         metadata['title'] = "Made up of other things"
 
         # Add some fake collation objects to the book.
-        content = '<p>composite</p>'
+        content = '<body><p>composite</p></body>'
         composite_doc = cnxepub.CompositeDocument(None, content, metadata)
         composite_section = cnxepub.TranslucentBinder(
             nodes=[composite_doc],
             metadata={'title': "Other things"})
 
-        baked_doc_content = '<p>collated</p>'
+        baked_doc_content = '<body><p>collated</p></body>'
 
         def cnxepub_collate(binder_model, ruleset=None, includes=None):
             binder_model[0][0].content = baked_doc_content
@@ -148,13 +148,13 @@ WHERE
         metadata['title'] = "Made up of other things"
 
         # Add some fake collation objects to the book.
-        content = '<p>composite</p>'
+        content = '<body><p>composite</p></body>'
         composite_doc = cnxepub.CompositeDocument(None, content, metadata)
         composite_section = cnxepub.TranslucentBinder(
             nodes=[composite_doc],
             metadata={'title': "Other things"})
 
-        baked_doc_content = '<p>collated</p>'
+        baked_doc_content = '<body><p>collated</p></body>'
 
         def cnxepub_collate(binder_model, ruleset=None, includes=None):
             binder_model[0][0].content = baked_doc_content

--- a/cnxpublishing/tests/test_db.py
+++ b/cnxpublishing/tests/test_db.py
@@ -112,7 +112,7 @@ VALUES (%s, %s, %s) RETURNING "id";""", args)
     def make_document(self, id=None, content=None, metadata=None):
         from cnxepub import Document
         if content is None:
-            content = io.BytesIO(b'<div><p>Blank.</p></div>')
+            content = io.BytesIO(b'<body><p>Blank.</p></body>')
         document = Document(id, content,
                             metadata=metadata)
         return document
@@ -1089,7 +1089,7 @@ VALUES
             'license_url': VALID_LICENSE_URL,
         }
         content = """
-            <div>
+            <body>
             <!-- Invalid references -->
             <img src="../resources/8bef27ba.png"/>
             <a href="/contents/765792e0-5e65-4411-88d3-90df8f48eb3a@55">
@@ -1110,7 +1110,7 @@ VALUES
             </a>
             <a href="#hello">anchor link</a>
             <a href="http://example.org/">external link</a>
-            </div>""" \
+            </body>""" \
                 .format(doc_ident_hash)
         document = self.make_document(content=content, metadata=metadata)
 
@@ -1134,7 +1134,7 @@ WHERE id = %s""", (publication_id,))
         state, state_messages = cursor.fetchone()
 
         self.assertEqual(state, 'Failed/Error')
-        xpath = u'/div/img'
+        xpath = u'/body/img'
         ref_value = u'../resources/8bef27ba.png'
         expected_message = u"Invalid reference at '{}'." \
                            .format(xpath)

--- a/cnxpublishing/tests/test_publish.py
+++ b/cnxpublishing/tests/test_publish.py
@@ -72,7 +72,7 @@ class PublishIntegrationTestCase(unittest.TestCase):
 
     def make_document(self, id=None, content=None, metadata=None):
         if content is None:
-            content = io.BytesIO(b'<p>Blank.</p>')
+            content = io.BytesIO(b'<body><p>Blank.</p></body>')
         document = cnxepub.Document(id, content, metadata=metadata)
         return document
 
@@ -644,7 +644,7 @@ class PublishCompositeDocumentTestCase(BaseDatabaseIntegrationTestCase):
         message = "Composite addition"
 
         # Add some fake collation objects to the book.
-        content = '<p class="para">composite</p>'
+        content = '<body><p class="para">composite</p></body>'
         composite_doc = cnxepub.CompositeDocument(None, content, metadata)
 
         ident_hash = self.target(cursor, composite_doc, binder,
@@ -696,7 +696,7 @@ class PublishCollatedDocumentTestCase(BaseDatabaseIntegrationTestCase):
         doc = [x for x in cnxepub.flatten_to_documents(binder)][0]
 
         # Add some fake collation objects to the book.
-        content = '<p class="para">collated</p>'
+        content = '<body><p class="para">collated</p></body>'
         doc.content = content
 
         self.target(cursor, doc, binder)
@@ -765,7 +765,7 @@ class PublishCollatedTreeTestCase(BaseDatabaseIntegrationTestCase):
         message = "Composite addition"
 
         # Add some fake collation objects to the book.
-        content = '<p class="para">composite</p>'
+        content = '<body><p class="para">composite</p></body>'
         composite_doc = cnxepub.CompositeDocument(None, content, metadata)
 
         from cnxpublishing.publish import publish_composite_model

--- a/cnxpublishing/tests/use_cases.py
+++ b/cnxpublishing/tests/use_cases.py
@@ -193,7 +193,7 @@ SPAM = cnxepub.Binder(
     nodes=[
         cnxepub.Document(
             id=u'2cf4d7d3@draft',
-            data=u'<p class="para">Yummy Yummy SPAM!!!</p>',
+            data=u'<body><p class="para">Yummy Yummy SPAM!!!</p></body>',
             resources=[],
             metadata={
                 u'title': u'Eat up!',
@@ -223,7 +223,7 @@ SPAM = cnxepub.Binder(
 
 PAGE_ONE = cnxepub.Document(
     id=u'2cf4d7d3@draft',
-    data=u'<p class="para">If you finish the book, there will be cake.</p>',
+    data=u'<body><p class="para">If you finish the book, there will be cake.</p></body>',
     metadata={
         u'title': u'Document One of Infinity',
         u'created': u'2013/03/19 15:01:16 -0500',
@@ -269,7 +269,7 @@ PAGE_ONE = cnxepub.Document(
 
 PAGE_TWO = cnxepub.Document(
     id=u'c24fe396@draft',
-    data=u'<p class="para">If you finish the book, there will be cake.</p>',
+    data=u'<body><p class="para">If you finish the book, there will be cake.</p></body>',
     metadata={
         u'title': u'Document Two of Infinity',
         u'created': u'2013/03/19 15:01:16 -0500',
@@ -309,7 +309,7 @@ PAGE_TWO = cnxepub.Document(
 
 PAGE_THREE = cnxepub.Document(
     id=u'e12b72ac@draft',
-    data=u'<p class="para">If you finish the book, there will be cake.</p>',
+    data=u'<body><p class="para">If you finish the book, there will be cake.</p></body>',
     metadata={
         u'title': u'Document Three of Infinity',
         u'created': u'2013/03/19 15:01:16 -0500',
@@ -349,7 +349,7 @@ PAGE_THREE = cnxepub.Document(
 
 PAGE_FOUR = cnxepub.Document(
     id=u'deadbeef@draft',
-    data=u'<p class="para">If you finish the böök, there will be cake.</p>',
+    data=u'<body><p class="para">If you finish the böök, there will be cake.</p></body>',
     metadata={
         u'title': u'Document Four of Infinity',
         u'created': u'2013/03/19 15:01:16 -0500',
@@ -383,7 +383,7 @@ PAGE_FOUR = cnxepub.Document(
 
 PAGE_FIVE = cnxepub.Document(
     id=u'b3627ba5@draft',
-    data=u'<p class="para">Download big file <a href="../resources/big-file.txt">here</a></p>',
+    data=u'<body><p class="para">Download big file <a href="../resources/big-file.txt">here</a></p></body>',
     resources=[
         cnxepub.Resource('big-file.txt',
                          # a 2 MB file
@@ -425,6 +425,7 @@ PAGE_FIVE = cnxepub.Document(
 EXERCISES_PAGE = cnxepub.Document(
     id=u'01234567@draft',
     data=u"""
+<body>
     <p class="para">
         <section>
             <div data-type="exercise" class="os-exercise">
@@ -463,6 +464,7 @@ EXERCISES_PAGE = cnxepub.Document(
             </div>
         </section>
     </p>
+</body>
     """,
     metadata={
         u'title': u'Exercises Page',

--- a/cnxpublishing/tests/views/test_publishing.py
+++ b/cnxpublishing/tests/views/test_publishing.py
@@ -1391,12 +1391,12 @@ class BakeContentTestCase(BaseFunctionalViewTestCase):
         # FIXME use collate with real ruleset when it is available
 
         # Add some fake collation objects to the book.
-        content = '<p>compösite</p>'
+        content = '<body><p>compösite</p></body>'
         publisher, message, composite_doc = self.make_one(binder, content)
         composite_section = cnxepub.TranslucentBinder(
             nodes=[composite_doc],
             metadata={'title': "Other things"})
-        collated_doc_content = '<p>cöllated</p>'
+        collated_doc_content = '<body><p>cöllated</p></body>'
 
         def _collate(binder_model, ruleset=None, includes=None):
             binder_model[0][0].content = collated_doc_content
@@ -1434,9 +1434,9 @@ class BakeContentTestCase(BaseFunctionalViewTestCase):
         binder = use_cases.setup_COMPLEX_BOOK_ONE_in_archive(self, cursor)
         cursor.connection.commit()
 
-        content = '<p class="para">composite</p>'
+        content = '<body><p class="para">composite</p></body>'
         publisher, message, composite_doc = self.make_one(binder, content)
-        collated_doc_content = '<p>collated</p>'
+        collated_doc_content = '<body><p>collated</p></body>'
 
         def _collate(binder_model, ruleset=None, includes=None):
             binder_model[0][0].content = collated_doc_content
@@ -1464,7 +1464,7 @@ class BakeContentTestCase(BaseFunctionalViewTestCase):
         binder = use_cases.setup_COMPLEX_BOOK_ONE_in_archive(self, cursor)
         cursor.connection.commit()
 
-        content = '<p class="para">composite</p>'
+        content = '<body><p class="para">composite</p></body>'
         publisher, message, composite_doc = self.make_one(binder, content)
 
         ident_hash = binder.ident_hash


### PR DESCRIPTION
Part of openstax/cnx-epub#139

---

Fix tests to use <body> when creating cnxepub.Document

`cnxepub.Document` now only accepts content with a `<body>` tag, so
update all the tests to work with this new requirement.
