### PR TITLE
Fix to explicitly install cnx-epub with collation support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ COPY . /src
 WORKDIR /src
 
 RUN set -x \
+    # FIXME: pip still has an issue with dependencies that have requirement
+    # extras. It understands the requirement but drops the extras part.
+    && python -m pip install "cnx-epub[collation]" \
     && python -m pip install -e ".[test]"
 
 ENV PYRAMID_INI environ.ini


### PR DESCRIPTION
This explicit install like is required, because pip is unable to install
dependencies with requirements extras. The results of this are an application
that complains about missing dependencies.

```pytb
Traceback (most recent call last):
  File "/usr/local/bin/pserve", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 32, in main
    return command.run()
  File "/usr/local/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 253, in run
    app = loader.get_wsgi_app(app_name, config_vars)
  File "/usr/local/lib/python2.7/site-packages/plaster_pastedeploy/__init__.py", line 131, in get_wsgi_app
    global_conf=defaults)
  ...
  File "/usr/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 645, in find_egg_entry_point
    pkg_resources.require(self.spec)
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 895, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 781, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'cnx-easybake; extra == "collation"' distribution was not found and is required by cnx-epub
```