### PR TITLE
Fix admin view template paths after refactoring

### DIFF
--- a/cnxpublishing/views/admin/content_status.py
+++ b/cnxpublishing/views/admin/content_status.py
@@ -237,7 +237,8 @@ def admin_content_status(request):
 
 
 @view_config(route_name='admin-content-status-single', request_method='GET',
-             renderer='templates/content-status-single.html',
+             renderer='cnxpublishing.views:'
+                      'templates/content-status-single.html',
              permission='view', http_cache=0)
 def admin_content_status_single(request):
     """
@@ -292,7 +293,8 @@ def admin_content_status_single(request):
 
 
 @view_config(route_name='admin-content-status-single', request_method='POST',
-             renderer='templates/content-status-single.html',
+             renderer='cnxpublishing.views:'
+                      'templates/content-status-single.html',
              permission='administer', http_cache=0)
 def admin_content_status_single_POST(request):
     """ Retriggers baking for a given book. """

--- a/cnxpublishing/views/admin/site_messages.py
+++ b/cnxpublishing/views/admin/site_messages.py
@@ -78,7 +78,7 @@ def parse_message_args(request):
 
 
 @view_config(route_name='admin-add-site-messages-POST', request_method='POST',
-             renderer='templates/site-messages.html',
+             renderer='cnxpublishing.views:templates/site-messages.html',
              permission='administer', http_cache=0)
 def admin_add_site_message_POST(request):
     # # If it was a post request to delete
@@ -111,7 +111,7 @@ def admin_add_site_message_POST(request):
 
 
 @view_config(route_name='admin-delete-site-messages', request_method='DELETE',
-             renderer='templates/site-messages.html',
+             renderer='cnxpublishing.views:templates/site-messages.html',
              permission='administer', http_cache=0)
 def admin_delete_site_message(request):
     message_id = request.body.split("=")[1]
@@ -127,7 +127,7 @@ def admin_delete_site_message(request):
 
 
 @view_config(route_name='admin-edit-site-message', request_method='GET',
-             renderer='templates/site-message-edit.html',
+             renderer='cnxpublishing.views:templates/site-message-edit.html',
              permission='administer', http_cache=0)
 def admin_edit_site_message(request):
     message_id = request.matchdict['id']
@@ -159,7 +159,7 @@ def admin_edit_site_message(request):
 
 
 @view_config(route_name='admin-edit-site-message-POST', request_method='POST',
-             renderer='templates/site-message-edit.html',
+             renderer='cnxpublishing.views:templates/site-message-edit.html',
              permission='administer', http_cache=0)
 def admin_edit_site_message_POST(request):
     message_id = request.matchdict['id']


### PR DESCRIPTION
We split the views in `cnxpublishing/views/admin.py` into submodules in
`0.15.1` and the submodules live in `cnxpublishing/views/admin/`.  Some
of the template paths didn't include the module, only the path so
`renderer="templates/content-status-single.html"` causing internal
server error on staging when accessing
https://staging.cnx.org/a/content-status/16ab5b96-4598-45f9-993c-b8d78d82b0c6

```
2019-03-20 19:02:08,087 ERROR [waitress][waitress] Exception when serving /a/content-status/16ab5b96-4598-45f9-993c-b8d78d82b0c6
Traceback (most recent call last):
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/waitress/channel.py", line 336, in service
    task.service()
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/waitress/task.py", line 175, in service
    self.execute()
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/waitress/task.py", line 452, in execute
    app_iter = self.channel.server.application(env, start_response)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/paste/deploy/config.py", line 291, in __call__
    return self.app(environ, start_response)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/router.py", line 270, in __call__
    response = self.execution_policy(environ, self)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/router.py", line 279, in default_execution_policy
    return request.invoke_exception_view(reraise=True)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/view.py", line 768, in invoke_exception_view
    reraise_(*exc_info)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/router.py", line 277, in default_execution_policy
    return router.invoke_request(request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/router.py", line 249, in invoke_request
    response = handle_request(request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid_sawing/main.py", line 39, in __call__
    request.response = self.handler(request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/tweens.py", line 43, in excview_tween
    response = _error_handler(request, exc)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/tweens.py", line 17, in _error_handler
    reraise(*exc_info)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/tweens.py", line 41, in excview_tween
    response = handler(request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/router.py", line 148, in handle_request
    registry, request, context, context_iface, view_name
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/view.py", line 657, in _call_view
    response = view_callable(context, request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/config/views.py", line 169, in __call__
    return view(context, request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/config/views.py", line 188, in attr_view
    return view(context, request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/config/views.py", line 214, in predicate_wrapper
    return view(context, request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/viewderivers.py", line 325, in secured_view
    return view(context, request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/viewderivers.py", line 275, in wrapper
    response = view(context, request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/viewderivers.py", line 460, in rendered_view
    request, result, view_inst, context
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/renderers.py", line 451, in render_view
    return self.render_to_response(response, system, request=request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/renderers.py", line 474, in render_to_response
    result = self.render(value, system_values, request=request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/renderers.py", line 470, in render
    result = renderer(value, system_values)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid_jinja2/__init__.py", line 264, in __call__
    template = self.template_loader()
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid_jinja2/__init__.py", line 283, in template_loader
    return self.environment.get_template(name)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/jinja2/environment.py", line 830, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/jinja2/environment.py", line 804, in _load_template
    template = self.loader.load(self, name, globals)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/jinja2/loaders.py", line 113, in load
    source, filename, uptodate = self.get_source(environment, name)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid_jinja2/__init__.py", line 250, in get_source
    raise TemplateNotFound(name=template, message=message)
TemplateNotFound: templates/content-status-single.html; searchpath=[]
```

This is fixed by changing the paths to include the module name so
`renderer="cnxpublishing.views:templates/content-status-single.html"`.

Address openstax/cnx#303