### PR TITLE
Change docker-compose db to build from github master

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ x-app-defaults: &app-defaults
 
 services:
   db:
-    image: openstax/cnx-db:latest
+    build: https://github.com/openstax/cnx-db.git
     volumes:
       - pgdata:/var/lib/postgresql/data
 


### PR DESCRIPTION
~It used to pull the latest openstax/cnx-db image, but we're not updating~
~it, causing the tests to fail...  @pumazi We can revert this change when docker~
~images are pushed after every cnx-db release.~

The latest openstax/cnx-db docker image doesn't have the latest
cnx-archive version `4.12.0+3.g58fc5a9` causing the tests to fail:

```
>       cursor.execute(stmt, params)
E       InternalError_: IOError: [Errno 2] No such file or directory: '/src/cnxdb/archive-sql/xpath.sql'
E       CONTEXT:  Traceback (most recent call last):
E         PL/Python function "assign_uuid_default", line 2, in <module>
E           from cnxarchive.database import assign_document_controls_default_trigger
E         PL/Python function "assign_uuid_default", line 75, in <module>
E         PL/Python function "assign_uuid_default", line 41, in _read_sql_file
E       PL/Python function "assign_uuid_default"
cnxpublishing/publish.py:217: InternalError_
___________________ ERROR at setup of test_recipe_selection ____________________
```
