### PR TITLE
Remove `<4.1.0` restriction for pytest in requirements/test.txt

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 cnx-db
 mock==1.0.1 ; python_version <= '2.7'
-pytest<4.1.0
+pytest
 pytest-cov
 pytest-mock
 pytest-runner


### PR DESCRIPTION
This fixes:

```
$ docker-compose run test bin/test
+ python -c 'import os, psycopg2 as p; dsn = os.environ['\''DB_SUPER_URL'\''].rsplit('\''/'\'', 1)[0] + '\''/postgres'\'';p.connect(dsn)'
+ echo 'Postgres is up - continuing execution'
Postgres is up - continuing execution
+ python -m pytest --strict cnxpublishing/tests
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/local/lib/python2.7/site-packages/pytest.py", line 91, in <module>
    raise SystemExit(pytest.main())
  File "/usr/local/lib/python2.7/site-packages/_pytest/config/__init__.py", line 58, in main
    config = _prepareconfig(args, plugins)
  File "/usr/local/lib/python2.7/site-packages/_pytest/config/__init__.py", line 182, in _prepareconfig
    config = get_config()
  File "/usr/local/lib/python2.7/site-packages/_pytest/config/__init__.py", line 153, in get_config
    pluginmanager.import_plugin(spec)
  File "/usr/local/lib/python2.7/site-packages/_pytest/config/__init__.py", line 522, in import_plugin
    __import__(importspec)
  File "/usr/local/lib/python2.7/site-packages/_pytest/tmpdir.py", line 25, in <module>
    class TempPathFactory(object):
  File "/usr/local/lib/python2.7/site-packages/_pytest/tmpdir.py", line 35, in TempPathFactory
    lambda p: Path(os.path.abspath(six.text_type(p)))
TypeError: attrib() got an unexpected keyword argument 'convert'
```