### PR TITLE
Initialize celery database tables before tasks run

### DIFF
--- a/cnxpublishing/tasks.py
+++ b/cnxpublishing/tasks.py
@@ -77,11 +77,18 @@ def includeme(config):
             Queue('deferred'),
         ),
     )
+
     # Override the existing Task class.
     config.registry.celery_app.Task = PyramidAwareTask
 
     # Set the default celery app so that the AsyncResult class is able
     # to assume the celery backend.
     config.registry.celery_app.set_default()
+
+    # Initialize celery database tables early
+    from celery.backends.database.session import SessionManager
+    session = SessionManager()
+    engine = session.get_engine(config.registry.celery_app.backend.url)
+    session.prepare_models(engine)
 
     config.add_directive('make_celery_app', _make_celery_app)


### PR DESCRIPTION
Was having issues where as soon as a baking task started, celery would try to create the task metadata tables several times, resulting in errors because the table would exist after the first try. This opts to generate the tables on app initialization rather than on the first task.